### PR TITLE
update dbt version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       DBT_PROFILES_DIR: ./integration_tests/ci
       DBT_PROJECT_DIR: ./integration_tests
       BIGQUERY_SERVICE_KEY_PATH: "/home/circleci/bigquery-service-key.json"
-      DBT_VERSION: 1.8.*
+      DBT_VERSION: 1.9.*
 
     steps:
       - checkout
@@ -104,7 +104,7 @@ jobs:
     environment:
       DBT_PROFILES_DIR: ./integration_tests/ci
       DBT_PROJECT_DIR: ./integration_tests
-      DBT_VERSION: 1.8.*
+      DBT_VERSION: 1.9.*
 
     steps:
       - checkout


### PR DESCRIPTION
## Summary of Changes

Update integration tests to point against 1.9, except for trino which hasn't released support for 1.9 yet.


## Reviewers
@tpoll @gusvargas
