### PR TITLE
Migrate dbt-date to GoDataDriven

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For latest release, see [https://github.com/metaplane/dbt-expectations/releases]
 
 ### Dependencies
 
-This package includes a reference to [`dbt-date`](https://github.com/calogica/dbt-date), so there's no need to also import `dbt-date` in your local project.
+This package includes a reference to [`dbt-date`](https://github.com/godatadriven/dbt-date), so there's no need to also import `dbt-date` in your local project.
 
 ### Variables
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
-  - package: calogica/dbt_date
+  - package: godatadriven/dbt_date
     version: [">=0.9.0", "<1.0.0"]


### PR DESCRIPTION
## Summary of Changes

Addresses #6. Xebia (formerly called GoDataDriven) have forked Calogica's `dbt-date` package ([here](https://github.com/godatadriven/dbt-date)) and will maintain it going forward as they are a partner of dbt Labs.

## Why Do We Need These Changes

If there is ever a feature or bug in `dbt-expectations` that relates to `dbt-date` then it would force Metaplane to fork and support their own `dbt-date` package. With Xebia's support this burden is now shared across the community.


## Reviewers
@tpoll @gusvargas
