### PR TITLE
Update dbt_date package to 0.11.0

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: godatadriven/dbt_date
-    version: [">=0.9.0", "<1.0.0"]
+    version: [">=0.11.0", "<0.12.0"]


### PR DESCRIPTION
## Summary of Changes

Update godatadriven/dbt-date to version 0.11.0 based on https://hub.getdbt.com/godatadriven/dbt_date/latest/

## Why Do We Need These Changes



## Reviewers
@tpoll @gusvargas
