### PR TITLE
Update README.md - suggest installing latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Include in `packages.yml`
 ```yaml
 packages:
     - package: metaplane/dbt_expectations
-      version: 0.10.6 # Check https://github.com/metaplane/dbt-expectations/releases for the latest release
+      version: 0.10.8 # Check https://github.com/metaplane/dbt-expectations/releases for the latest release
 ```
 
 This package supports:


### PR DESCRIPTION
Installing with 0.10.6 as instructed in the docs gives the following warning:

```
dbt deps
10:22:50  Running with dbt=1.9.4
10:22:51  [WARNING]: Deprecated functionality
The `calogica/dbt_date` package is deprecated in favor of
`godatadriven/dbt_date`. Please update your `packages.yml` configuration to use
`godatadriven/dbt_date` instead.
10:22:51  Updating lock file in file path: package-lock.yml
10:22:51  Installing metaplane/dbt_expectations
10:22:52  Installed from version 0.10.6
10:22:52  Updated version available: 0.10.8
10:22:52  Installing calogica/dbt_date
10:22:52  Installed from version 0.10.1
10:22:52  Up to date!
10:22:52
10:22:52  Updates available for packages: ['metaplane/dbt_expectations']
Update your versions in packages.yml, then run dbt deps
```

Updating to 0.10.8 resolves this.

## Summary of Changes

Update recommended version to install in documentation

## Why Do We Need These Changes

Prevents scary warnings. 


## Reviewers
@tpoll @gusvargas
