### PR TITLE
fix: division by Zero in expect_column_proportion_of_unique_values_to_be_between with empty tables

### DIFF
--- a/macros/schema_tests/aggregate_functions/expect_column_proportion_of_unique_values_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_proportion_of_unique_values_to_be_between.sql
@@ -6,7 +6,10 @@
                                                             strictly=False
                                                             ) %}
 {% set expression %}
-cast(count(distinct {{ column_name }}) as {{ dbt.type_float() }})/count({{ column_name }})
+case 
+  when count({{ column_name }}) = 0 then 1 -- Return 1 if division by zero
+  else cast(count(distinct {{ column_name }}) as {{ dbt.type_float() }})/count({{ column_name }})
+end
 {% endset %}
 {{ dbt_expectations.expression_between(model,
                                         expression=expression,


### PR DESCRIPTION
## Summary of Changes

Add a case when statement to return 1 when count of values are zero.

## Why Do We Need These Changes

fixes https://github.com/metaplane/dbt-expectations/issues/19


## Reviewers
@tpoll @gusvargas
