### PR TITLE
Drop deprecated sqlfluff recurse config

### DIFF
--- a/integration_tests/.sqlfluff
+++ b/integration_tests/.sqlfluff
@@ -5,7 +5,6 @@ dialect = postgres
 templater = dbt
 rules = None
 exclude_rules = L003,L011,L022,L031
-recurse = 0
 output_line_length = 100
 
 [sqlfluff:templater:dbt]


### PR DESCRIPTION
## Summary of Changes

Removes a config option deprecated by [sqlfluff here](https://docs.sqlfluff.com/en/stable/reference/releasenotes.html). 

## Why Do We Need These Changes
    
Removing this option will prevent users from running into errors like the one below while trying to use sqlfluff in a dbt project where dbt-expectations is installed. 
```
==== finding fixable violations ====

User Error: Config file PosixPath('/Users/myusername/Documents/dbt_project/dbt_packages/dbt_expectations/integration_tests/.sqlfluff') set an outdated config value core:recurse.

Removed as unused in production and unnecessary for debugging.

See https://docs.sqlfluff.com/en/stable/perma/configuration.html for more details.
```


## Reviewers
@tpoll @gusvargas
