### PR TITLE
Fix #23 stop assigning list from list.append

### DIFF
--- a/macros/schema_tests/multi-column/expect_compound_columns_to_be_unique.sql
+++ b/macros/schema_tests/multi-column/expect_compound_columns_to_be_unique.sql
@@ -15,7 +15,7 @@
 {% elif quote_columns %}
     {%- set columns=[] %}
         {% for column in column_list -%}
-            {% set columns = columns.append( adapter.quote(column) ) %}
+            {% do columns.append( adapter.quote(column) ) %}
         {%- endfor %}
 {% else %}
     {{ exceptions.raise_compiler_error(

--- a/macros/schema_tests/multi-column/expect_select_column_values_to_be_unique_within_record.sql
+++ b/macros/schema_tests/multi-column/expect_select_column_values_to_be_unique_within_record.sql
@@ -19,7 +19,7 @@
 {% elif quote_columns %}
     {%- set columns=[] %}
         {% for column in column_list -%}
-            {% set columns = columns.append( adapter.quote(column) ) %}
+            {% do columns.append( adapter.quote(column) ) %}
         {%- endfor %}
 {% else %}
     {{ exceptions.raise_compiler_error(


### PR DESCRIPTION
## Summary of Changes
Fixes #23 
Change `{% set columns = columns.append(...) %}` to `{% do  columns.append(...) %}` 

## Why Do We Need These Changes
Otherwise dbt-fusion won't work with dbt-expectations.  They said they don't plan on fixing https://github.com/dbt-labs/dbt-fusion/issues/484, which seems reasonable. 


## Reviewers
@tpoll @gusvargas
