### PR TITLE
fix: expect_column_values_to_have_consistent_casing correctly dealing with NULL values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+## Fixes
+* Fix `expect_column_values_to_have_consistent_casing` to correctly handle `NULL` values in columns.
+
 # dbt-expectations v0.10.5
 ## Fixes
 * Update CI for dbt 1.9.x https://github.com/metaplane/dbt-expectations/pull/2

--- a/integration_tests/models/schema_tests/data_test.sql
+++ b/integration_tests/models/schema_tests/data_test.sql
@@ -55,3 +55,18 @@ select
     1.0 as col_numeric_a_plus_b,
     8 as idx_multiplied_by_2,
     -8 as idx_multiplied_by_minus_2
+
+union all
+
+select
+    5 as idx,
+    '2020-10-23' as date_col,
+    0.5 as col_numeric_a,
+    0.5 as col_numeric_b,
+    NULL as col_string_a,
+    'abcde' as col_string_b,
+    null as col_null,
+    null as col_null_2,
+    1 as col_numeric_a_plus_b,
+    10 as idx_multiplied_by_2,
+    -10 as idx_multiplied_by_minus_2

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -404,14 +404,14 @@ models:
           column_list: ["col_null", "col_null_2"]
           ignore_row_if: "all_values_are_missing"
       - dbt_expectations.expect_table_row_count_to_equal:
-          value: 4
+          value: 5
       - dbt_expectations.expect_table_row_count_to_be_between:
           min_value: 1
-          max_value: 4
+          max_value: 5
       - dbt_expectations.expect_table_row_count_to_be_between:
           min_value: 1
       - dbt_expectations.expect_table_row_count_to_be_between:
-          max_value: 4
+          max_value: 5
       - dbt_expectations.expect_table_row_count_to_equal_other_table:
           compare_model: ref("data_test")
           row_condition: 1=1
@@ -476,7 +476,7 @@ models:
           ignore_row_if: "any_value_is_missing"
       - dbt_expectations.expect_multicolumn_sum_to_equal:
           column_list: ["col_numeric_a", "col_numeric_b"]
-          sum_total: 4
+          sum_total: 5
       - dbt_expectations.expect_multicolumn_sum_to_equal:
           column_list: ["col_numeric_a", "col_numeric_b"]
           sum_total: col_numeric_a_plus_b
@@ -543,15 +543,18 @@ models:
         tests:
           - dbt_expectations.expect_column_values_to_be_in_set:
               value_set: ['a', 'b', 'c']
+              row_condition: 'col_string_a is not NULL'
               quote_values: true
           - dbt_expectations.expect_column_values_to_not_be_in_set:
               value_set: ['2','3']
               quote_values: true
           - dbt_expectations.expect_column_distinct_values_to_equal_set:
               value_set: ['a','b','c','c']
+              row_condition: 'col_string_a is not NULL'
           - dbt_expectations.expect_column_distinct_values_to_be_in_set:
               value_set: ['a','b','c','d']
               quote_values: true
+              row_condition: 'col_string_a is not NULL'
           - dbt_expectations.expect_column_distinct_values_to_contain_set:
               value_set: ['a','b']
           - dbt_expectations.expect_column_value_lengths_to_equal:
@@ -560,7 +563,7 @@ models:
           - dbt_expectations.expect_column_values_to_have_consistent_casing:
               display_inconsistent_columns: true
           - dbt_expectations.expect_column_distinct_count_to_be_less_than:
-              value: 4
+              value: 5
 
       - name: col_string_b
         tests:
@@ -569,11 +572,11 @@ models:
               quote_values: true
           - dbt_expectations.expect_column_value_lengths_to_be_between:
               min_value: 1
-              max_value: 4
+              max_value: 5
           - dbt_expectations.expect_column_value_lengths_to_be_between:
               min_value: 1
           - dbt_expectations.expect_column_value_lengths_to_be_between:
-              max_value: 4
+              max_value: 5
 
       - name: col_null
         tests:

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_have_consistent_casing.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_have_consistent_casing.sql
@@ -26,7 +26,7 @@ with test_data as (
  validation_errors as (
 
     select
-        count(1) as set_count,
+        count(distinct_values) as set_count,
         count(distinct lower(distinct_values)) as set_count_case_insensitive
     from
         test_data


### PR DESCRIPTION

## Summary of Changes

This PR fixes #27 where NULL values in a column cause the `expect_column_values_to_have_consistent_casing` to fail for an otherwise consistently cased column. 

I've added the change, and updated the tests so that they fail without the fix, and succeed with the fix.

## Why Do We Need These Changes

The current implementation fails for columns with consistent casing that contain NULL values. When enabling the `display_inconsistent_columns` feature of the test, the test succeeds because of the changes in the underlying logic.

## Reviewers
@tpoll @gusvargas
