### PR TITLE
Add`expect_multicolumn_sum_to_be_between` data test

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ For example, use `America/New_York` for East Coast Time.
 - [expect_column_pair_values_to_be_in_set](#expect_column_pair_values_to_be_in_set)
 - [expect_compound_columns_to_be_unique](#expect_compound_columns_to_be_unique)
 - [expect_multicolumn_sum_to_equal](#expect_multicolumn_sum_to_equal)
+- [expect_multicolumn_sum_to_be_between](#expect_multicolumn_sum_to_be_between)
 - [expect_select_column_values_to_be_unique_within_record](#expect_select_column_values_to_be_unique_within_record)
 
 ### Distributional functions
@@ -1099,6 +1100,23 @@ tests:
       sum_total: 4
       group_by: [group_id, other_group_id, ...] # (Optional)
       row_condition: "id is not null" # (Optional)
+```
+
+### [expect_multicolumn_sum_to_be_between](macros/schema_tests/multi-column/expect_multicolumn_sum_to_be_between.sql)
+
+Expects that sum of all rows for a set of columns is between two values.
+
+*Applies to:* Model, Seed, Source
+
+```yaml
+tests:
+  - dbt_expectations.expect_multicolumn_sum_to_be_between:
+      column_list: ["col_numeric_a", "col_numeric_b"]
+      min_value: 3
+      max_value: 5
+      group_by: [group_id, other_group_id, ...] # (Optional)
+      row_condition: "id is not null" # (Optional)
+      strictly: false # (Optional)
 ```
 
 ### [expect_compound_columns_to_be_unique](macros/schema_tests/multi-column/expect_compound_columns_to_be_unique.sql)

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -484,7 +484,21 @@ models:
           column_list: ["col_numeric_a", "col_numeric_b"]
           sum_total: col_numeric_a_plus_b
           group_by: [idx]
-
+      - dbt_expectations.expect_multicolumn_sum_to_be_between:
+          column_list: ["col_numeric_a", "col_numeric_b"]
+          min_value: 3
+          max_value: 5
+          strictly: true
+      - dbt_expectations.expect_multicolumn_sum_to_be_between:
+          column_list: ["col_numeric_a", "col_numeric_b"]
+          min_value: 4
+          max_value: 4
+          strictly: false
+      - dbt_expectations.expect_multicolumn_sum_to_be_between:
+          column_list: ["col_numeric_a", "col_numeric_b"]
+          min_value: col_numeric_a_plus_b
+          max_value: col_numeric_a_plus_b
+          strictly: false
 
     columns:
       - name: idx

--- a/macros/schema_tests/multi-column/expect_multicolumn_sum_to_be_between.sql
+++ b/macros/schema_tests/multi-column/expect_multicolumn_sum_to_be_between.sql
@@ -1,0 +1,54 @@
+
+{% test expect_multicolumn_sum_to_be_between(model,
+                                                column_list,
+                                                min_value=None,
+                                                max_value=None,
+                                                group_by=None,
+                                                row_condition=None,
+                                                strictly=False
+                                                ) %}
+
+{% set expression %}
+{% for column in column_list %}
+sum({{ column }}){% if not loop.last %} + {% endif %}
+{# the if just allows for column names or literal numbers #}
+{% endfor %}
+{% endset %}
+
+{%- if min_value is none and max_value is none -%}
+{{ exceptions.raise_compiler_error(
+    "You have to provide either a min_value, max_value or both."
+) }}
+{%- endif -%}
+
+{%- set strict_operator = "" if strictly else "=" -%}
+
+{% set expression_min_max %}
+( 1=1
+{%- if min_value is not none %} 
+    and {{ expression | trim }} >{{ strict_operator }} 
+    {% if min_value is number %}
+        {{min_value}}
+    {% else %}
+        sum({{ min_value }})
+    {% endif %}
+{% endif %}
+
+{%- if max_value is not none %} 
+    and {{ expression | trim }} <{{ strict_operator }} 
+    {% if max_value is number %}
+        {{max_value}}
+    {% else %}
+        sum({{ max_value }})
+    {% endif %}
+{% endif %}
+)
+{% endset %}
+
+{{ dbt_expectations.expression_is_true(model,
+                                        expression=expression_min_max,
+                                        group_by_columns=group_by_columns,
+                                        row_condition=row_condition)
+                                        }}
+
+{% endtest %}


### PR DESCRIPTION
## Summary of Changes

* Added `expect_multicolumn_sum_to_be_between` data test
* Added integration tests for new data test
* Added docs for new data test

## Why Do We Need These Changes

To be able to compare the sum of multiple columns is not greater or smaller than a given value. 
Example would be the number of sales of product A in column `num_sales_A` and for product B in `num_sales_B`. The total sales would be in `num_total_sales`. 
To make sure that the sum of A and B is not greater than the total (which could include a product C), this data test could be used.

## Reviewers
@tpoll @gusvargas
