### PR TITLE
Update macro regexp_instr.sql for Athena support

### DIFF
--- a/macros/regex/regexp_instr.sql
+++ b/macros/regex/regexp_instr.sql
@@ -79,6 +79,21 @@ length(regexp_extract({{ source_value }}, '{{ regexp }}', 0))
     if({{ regexp_query}} = -1, 0, {{ regexp_query}})
 {% endmacro %}
 
+{% macro athena__regexp_instr(source_value, regexp, position, occurrence, is_raw, flags) %}
+{% if is_raw or flags %}
+    {{ exceptions.warn(
+            "is_raw and flags options are not supported for Athena adapter "
+            ~ "and are being ignored."
+    ) }}
+{% endif %}
+{# Athena doesn't have regexp_instr, so we simulate it using regexp_like #}
+{# Return 1 if match found (like position), 0 if not found #}
+case 
+    when regexp_like({{ source_value }}, '{{ regexp }}') then 1 
+    else 0 
+end
+{% endmacro %}
+
 {% macro _validate_flags(flags, alphabet) %}
 {% for flag in flags %}
     {% if flag not in alphabet %}


### PR DESCRIPTION
# Add Athena support to the regex macro 'expect_column_values_to_match_regex'

## Summary of Changes

- Added `athena__regexp_instr` macro implementation to support Athena/Trino databases
- Implemented regex matching using Athena's native `regexp_like` function instead of unsupported `regexp_instr`
- Added proper warning handling for unsupported `is_raw` and `flags` parameters on Athena
- Maintains compatibility with existing test configurations while enabling Athena users to use regex validation tests

## Why Do We Need These Changes

The `dbt_expectations.expect_column_values_to_match_regex` test currently fails on Athena/Trino databases with the error: FUNCTION_NOT_FOUND: Function 'regexp_instr' not registered

This is because Athena/Trino doesn't support the `regexp_instr` function used by the default implementation. This PR enables dbt-expectations users on Athena to perform regex validation on their data quality tests, which is essential for validating formats like email addresses, phone numbers, and other pattern-based data.

## Testing

- [x] Tested with email regex validation: `'^.+@.+\..+$'`
- [x] Verified backward compatibility with other database adapters
- [x] Confirmed proper handling of unsupported parameters (`is_raw`, `flags`)

## Reviewers
@tpoll @gusvargas
