### PR TITLE
Bump package compatibility version

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -5,7 +5,7 @@
 name: 'dbt_expectations'
 version: '0.6.0'
 
-require-dbt-version: [">=1.7.0", "<2.0.0"]
+require-dbt-version: [">=1.7.0", "<3.0.0"]
 config-version: 2
 
 target-path: "target"


### PR DESCRIPTION
## Summary of Changes

 bumped v 2.0.0 to 3.0.0 [require-dbt-version: [">=1.7.0", "<3.0.0"]]

## Why Do We Need These Changes

Updates `require-dbt-version` to prevent compatibility warnings in Fusion and ensure correct display on dbt Hub.

After merging, please publish a new tagged release so the update is picked up by Hub.


## Reviewers
@tpoll @gusvargas
