### PR TITLE
fix: change group by alias to positional to support trino engine

### DIFF
--- a/macros/schema_tests/distributional/expect_row_values_to_have_data_for_every_n_datepart.sql
+++ b/macros/schema_tests/distributional/expect_row_values_to_have_data_for_every_n_datepart.sql
@@ -105,7 +105,7 @@ model_data as (
     where {{ row_condition }}
     {% endif %}
     group by
-        date_{{date_part}}
+        1
 
 ),
 


### PR DESCRIPTION
## Summary of Changes

Changed the grouping logic in the expect_row_values_to_have_data_for_every_n_datepart test macro. Specifically, replaced the alias-based grouping (group by date_{{date_part}}) with a positional grouping (group by 1).

## Why Do We Need These Changes

This change fixes a SQL compilation error when running this test on Trino or Presto engines.

These engines resolve the GROUP BY clause before the SELECT projection, meaning they cannot resolve the column alias defined in the SELECT statement, causing a "Column not found" error.

Using GROUP BY 1:
1. Resolves the issue on Trino/Starburst.
2. Maintains compatibility with other supported adapters.

Closes #39


## Reviewers
@GuruM
