### PR TITLE
Update dbt_expectations package version to 0.10.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Include in `packages.yml`
 ```yaml
 packages:
     - package: metaplane/dbt_expectations
-      version: 0.10.9 # Check https://github.com/metaplane/dbt-expectations/releases for the latest release
+      version: 0.10.10 # Check https://github.com/metaplane/dbt-expectations/releases for the latest release
 ```
 
 This package supports:


### PR DESCRIPTION
## Summary of Changes

Minor update: Since 2 Dec, the latest version is 0.10.10

## Why Do We Need These Changes

When people copy-paste code to `packages.yml` from the official repo they shouldn't see a deprecation warning.

Also my personal motivation here is that I'm delivering a class where we'll use this module in a few days and want to ensure students have the smotthest possible experience.

## Reviewers
@GuruM
