### PR TITLE
allow expressions in group_by of expect_grouped_row_values_to_have_re…

### DIFF
--- a/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
+++ b/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
@@ -23,7 +23,10 @@
 with latest_grouped_timestamps as (
 
     select
-        {{ group_by | join(",") ~ "," if group_by }}
+        {% if group_by %}
+        {% for g in group_by %}{{ g }} as dbt_expectations_group_by_{{ loop.index }},
+        {% endfor %}
+        {% endif %}
         max(1) as join_key,
         max(cast({{ timestamp_column }} as {{ dbt_expectations.type_timestamp() }})) as latest_timestamp_column
     from
@@ -42,7 +45,10 @@ with latest_grouped_timestamps as (
 total_row_counts as (
 
     select
-        {{ group_by | join(",") ~ "," if group_by }}
+        {% if group_by %}
+        {% for _ in group_by %}dbt_expectations_group_by_{{ loop.index }},
+        {% endfor %}
+        {% endif %}
         max(1) as join_key,
         count(*) as row_count
     from
@@ -78,7 +84,7 @@ validation_errors as (
         outdated_grouped_timestamps t
         on
             {% for g in group_by %}
-            r.{{ g }} = t.{{ g }} and
+            r.dbt_expectations_group_by_{{ loop.index }} = t.dbt_expectations_group_by_{{ loop.index }} and
             {% endfor %}
             r.join_key = t.join_key
     where


### PR DESCRIPTION
## Summary of Changes

To allow expressions like `JSON_VALUE(json_col.field)` in group_by columns in the expect_grouped_row_values_to_have_recent_data test, the first occurrence of group_by columns is aliase. Later references then use this alias.

## Why Do We Need These Changes

Some of our models make use of JSON type columns.
Information inside the JSON is needed to determine groups which should have recent data.
This PR avoids unpacking the JSON into further columns within the same model or even creating a downstream model just to test on.

## Reviewers
@GuruM


## Notes
I ran the integration_tests project and tested our use case with a local installation of dbt-expectations.

If you need further info or changes, let me know.