### PR TITLE
Fix expect_column_to_exist rendering Python booleans as SQL literals

### DIFF
--- a/macros/schema_tests/table_shape/expect_column_to_exist.sql
+++ b/macros/schema_tests/table_shape/expect_column_to_exist.sql
@@ -10,11 +10,11 @@
 
         {%- set column_index_0 = column_index - 1 if column_index > 0 else 0 -%}
 
-        {%- set column_index_matches = true if matching_column_index == column_index_0 else false %}
+        {%- set column_index_matches = 1 if matching_column_index == column_index_0 else 0 %}
 
     {%- else -%}
 
-        {%- set column_index_matches = true -%}
+        {%- set column_index_matches = 1 -%}
 
     {%- endif %}
 
@@ -29,7 +29,7 @@
     select *
     from test_data
     where
-        not(matching_column_index >= 0 and column_index_matches)
+        not(matching_column_index >= 0 and column_index_matches = 1)
 
 {%- endif -%}
 {%- endtest -%}


### PR DESCRIPTION
## Summary

- Replaces Python `True`/`False` with integer literals `1`/`0` in the `expect_column_to_exist` test macro
- Adds `= 1` comparison in the `WHERE` clause instead of relying on implicit boolean evaluation
- T-SQL (Microsoft Fabric, SQL Server, Azure SQL) has no boolean type, so `True`/`False` are invalid SQL literals on those platforms

Fixes #43

## Test plan

- [ ] Run `expect_column_to_exist` test on a T-SQL adapter (dbt-fabric, dbt-sqlserver) — should no longer error
- [ ] Run `expect_column_to_exist` test on PostgreSQL/Snowflake/BigQuery — should still pass (integer `1`/`0` work as booleans on all platforms)
- [ ] Test with and without the `column_index` parameter