### PR TITLE
Fix positional GROUP BY in expect_column_values_to_have_consistent_casing

### DIFF
--- a/macros/schema_tests/column_values_basic/expect_column_values_to_have_consistent_casing.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_have_consistent_casing.sql
@@ -16,7 +16,7 @@ with test_data as (
         count(distinct_values) as set_count_case_insensitive
     from
         test_data
-    group by 1
+    group by lower(distinct_values)
     having
         count(distinct_values) > 1
 


### PR DESCRIPTION
## Summary

- Replaces `GROUP BY 1` with `GROUP BY lower(distinct_values)` in the `expect_column_values_to_have_consistent_casing` test macro
- T-SQL (Microsoft Fabric, SQL Server, Azure SQL) does not support positional `GROUP BY` references
- Explicit column expressions work on all SQL dialects

Fixes #44

## Test plan

- [ ] Run `expect_column_values_to_have_consistent_casing` with `display_inconsistent_columns=True` on a T-SQL adapter — should no longer error
- [ ] Run the same test on PostgreSQL/Snowflake/BigQuery — should still pass
- [ ] Test both `display_inconsistent_columns=True` and `display_inconsistent_columns=False` paths