### PR TITLE
sql server dispatch target in true, truth, and logarithm macros

### DIFF
--- a/macros/math/log_natural.sql
+++ b/macros/math/log_natural.sql
@@ -25,3 +25,9 @@
     ln({{ x }})
 
 {%- endmacro -%}
+
+{% macro sqlserver__log_natural(x) -%}
+
+    log({{ x }})
+
+{%- endmacro -%}

--- a/macros/schema_tests/_generalized/_truth_expression.sql
+++ b/macros/schema_tests/_generalized/_truth_expression.sql
@@ -6,3 +6,7 @@
 {% macro default__truth_expression(expression) %}
   {{ expression }} as expression
 {% endmacro %}
+
+{% macro sqlserver__truth_expression(expression) %}
+  case when {{ expression }} then 1 else 0 end as expression
+{% endmacro %}

--- a/macros/schema_tests/_generalized/expression_is_true.sql
+++ b/macros/schema_tests/_generalized/expression_is_true.sql
@@ -56,3 +56,42 @@ from validation_errors
 
 
 {% endmacro -%}
+
+{% macro sqlserver__expression_is_true(model, expression, test_condition, group_by_columns, row_condition) -%}
+with grouped_expression as (
+    select
+        {% if group_by_columns %}
+        {% for group_by_column in group_by_columns -%}
+        {{ group_by_column }} as col_{{ loop.index }},
+        {% endfor -%}
+        {% endif %}
+        {{ dbt_expectations.truth_expression(expression) }}
+    from {{ model }}
+     {%- if row_condition %}
+    where
+        {{ row_condition }}
+    {% endif %}
+    {% if group_by_columns %}
+    group by
+    {% for group_by_column in group_by_columns -%}
+        {{ group_by_column }}{% if not loop.last %},{% endif %}
+    {% endfor %}
+    {% endif %}
+
+),
+validation_errors as (
+
+    select
+        *
+    from
+        grouped_expression
+    where
+        not(expression =1)
+
+)
+
+select *
+from validation_errors
+
+
+{% endmacro -%}


### PR DESCRIPTION
## Summary of Changes

Introduces partial SQL Server support.

## Why Do We Need These Changes

Expectations that use one of the three macros changed in this PR can not be run against SQL Server at the moment.
In SQL Server world, booleans only exist in conditions and it is necessary to use 0 or 1 bits in selection sets instead. 


## Reviewers
@GuruM

Is related to #47 
