### PR TITLE
fix dbt lint warnings

### DIFF
--- a/macros/math/percentile_cont.sql
+++ b/macros/math/percentile_cont.sql
@@ -2,7 +2,7 @@
   {{ adapter.dispatch('quantile', 'dbt_expectations') (field, quantile, partition) }}
 {% endmacro %}
 
-{% macro default__quantile(field, quantile, partition)  -%}
+{% macro default__quantile(field, quantile, partition) -%}
     percentile_cont({{ quantile }}) within group (order by {{ field }})
     {%- if partition %}over(partition by {{ partition }}){% endif -%}
 {%- endmacro %}

--- a/macros/regex/regexp_instr.sql
+++ b/macros/regex/regexp_instr.sql
@@ -76,7 +76,7 @@ length(regexp_extract({{ source_value }}, '{{ regexp }}', 0))
     {% endif %}
     {%- set regexp_query = "regexp_position(" ~ source_value ~ ", '" ~ regexp ~ "', " ~ position ~ ", " ~ occurrence ~ ")" -%}
     {# Trino regexp_position returns -1 if not found. Change it to 0, to be consistent with other adapters #}
-    if({{ regexp_query}} = -1, 0, {{ regexp_query}})
+    if({{ regexp_query }} = -1, 0, {{ regexp_query }})
 {% endmacro %}
 
 {% macro _validate_flags(flags, alphabet) %}
@@ -97,9 +97,9 @@ length(regexp_extract({{ source_value }}, '{{ regexp }}', 0))
 {# m  :  multi-line mode: ^ and $ match begin/end line in addition to begin/end text (default false) #}
 {# s  :  let . match \n (default false) #}
 {# U  :  ungreedy: swap meaning of x* and x*?, x+ and x+?, etc (default false) #}
-{# Flag syntax is xyz (set) or -xyz (clear) or xy-z (set xy, clear z).  #}
+{# Flag syntax is xyz (set) or -xyz (clear) or xy-z (set xy, clear z). #}
 
-{# Regex explanation: do not allow consecutive dashes, accept all re2 flags and clear operator, do not end with a dash  #}
+{# Regex explanation: do not allow consecutive dashes, accept all re2 flags and clear operator, do not end with a dash #}
 {% set re2_flags_pattern = '^(?!.*--)[-imsU]*(?<!-)$' %}
 {% set re = modules.re %}
 {% set is_match = re.match(re2_flags_pattern, flags) %}

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_decreasing.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_decreasing.sql
@@ -31,7 +31,7 @@ add_lag_values as (
                 (order by sort_column)
             {%- else -%}
                 (partition by {{ group_by | join(", ") }} order by sort_column)
-            {%- endif  %} as value_field_lag
+            {%- endif %} as value_field_lag
     from
         all_values
 

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_increasing.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_increasing.sql
@@ -34,7 +34,7 @@ add_lag_values as (
                 (order by sort_column)
             {%- else -%}
                 (partition by {{ group_by | join(", ") }} order by sort_column)
-            {%- endif  %} as value_field_lag
+            {%- endif %} as value_field_lag
     from
         all_values
 

--- a/macros/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
+++ b/macros/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
@@ -69,7 +69,7 @@ with metric_values as (
             sum({{ column_name }}) as agg_metric_value
         from
             {{ model }}
-        {{  dbt_expectations.group_by(1 + group_by_length) }}
+        {{ dbt_expectations.group_by(1 + group_by_length) }}
 
     )
     {%- if take_diffs %}

--- a/macros/schema_tests/distributional/expect_column_values_to_be_within_n_stdevs.sql
+++ b/macros/schema_tests/distributional/expect_column_values_to_be_within_n_stdevs.sql
@@ -24,7 +24,7 @@ with metric_values as (
     from
         {{ model }}
     {% if group_by -%}
-    {{  dbt_expectations.group_by(group_by | length) }}
+    {{ dbt_expectations.group_by(group_by | length) }}
     {%- endif %}
 
 ),

--- a/macros/schema_tests/distributional/expect_row_values_to_have_data_for_every_n_datepart.sql
+++ b/macros/schema_tests/distributional/expect_row_values_to_have_data_for_every_n_datepart.sql
@@ -65,7 +65,7 @@ with base_dates as (
     #}
     where mod(
             cast({{ dbt.datediff("'" ~ start_date ~ "'", 'date_' ~ date_part, date_part) }} as {{ dbt.type_int() }}),
-            cast({{interval}} as {{ dbt.type_int() }})
+            cast({{ interval }} as {{ dbt.type_int() }})
         ) = 0
     {% endif %}
 
@@ -94,7 +94,7 @@ model_data as (
                 cast(" ~ interval ~ " as  " ~ dbt.type_int() ~ " )
             ) * (-1)",
             "cast( " ~ dbt.date_trunc(date_part, date_col) ~ " as  " ~ dbt_expectations.type_datetime() ~ ")"
-        )}} as date_{{ date_part }},
+        ) }} as date_{{ date_part }},
 
     {% endif %}
 
@@ -105,7 +105,7 @@ model_data as (
     where {{ row_condition }}
     {% endif %}
     group by
-        date_{{date_part}}
+        date_{{ date_part }}
 
 ),
 

--- a/macros/schema_tests/multi-column/expect_compound_columns_to_be_unique.sql
+++ b/macros/schema_tests/multi-column/expect_compound_columns_to_be_unique.sql
@@ -25,7 +25,7 @@
 
 {%- set row_condition_ext -%}
 
-    {%- if row_condition  %}
+    {%- if row_condition %}
     {{ row_condition }} and
     {% endif -%}
 
@@ -39,7 +39,7 @@ with validation_errors as (
         {% for column in columns -%}
         {{ column }},
         {%- endfor %}
-        count(*) as {{adapter.quote("n_records")}}
+        count(*) as {{ adapter.quote("n_records") }}
     from {{ model }}
     where
         1=1

--- a/macros/schema_tests/multi-column/expect_multicolumn_sum_to_equal.sql
+++ b/macros/schema_tests/multi-column/expect_multicolumn_sum_to_equal.sql
@@ -10,7 +10,7 @@
 {% for column in column_list %}
 sum({{ column }}){% if not loop.last %} + {% endif %}
 {# the if just allows for column names or literal numbers #}
-{% endfor %} = {% if sum_total is number %}{{sum_total}}{% else %}sum({{ sum_total }}){% endif %}
+{% endfor %} = {% if sum_total is number %}{{ sum_total }}{% else %}sum({{ sum_total }}){% endif %}
 {% endset %}
 
 {{ dbt_expectations.expression_is_true(model,

--- a/macros/schema_tests/multi-column/expect_select_column_values_to_be_unique_within_record.sql
+++ b/macros/schema_tests/multi-column/expect_select_column_values_to_be_unique_within_record.sql
@@ -3,7 +3,7 @@
                                                     quote_columns=False,
                                                     ignore_row_if="all_values_are_missing",
                                                     row_condition=None
-                                                    )  -%}
+                                                    ) -%}
     {{ adapter.dispatch('test_expect_select_column_values_to_be_unique_within_record', 'dbt_expectations') (model, column_list, quote_columns, ignore_row_if, row_condition) }}
 {%- endtest %}
 
@@ -29,7 +29,7 @@
 
 {%- set row_condition_ext -%}
 
-    {%- if row_condition  %}
+    {%- if row_condition %}
     {{ row_condition }} and
     {% endif -%}
 

--- a/macros/schema_tests/string_matching/expect_column_values_to_match_like_pattern_list.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_match_like_pattern_list.sql
@@ -8,7 +8,7 @@
     {% for like_pattern in like_pattern_list %}
     {{ dbt_expectations._get_like_pattern_expression(column_name, like_pattern, positive=True) }}
     {%- if not loop.last %}
-    {{ " and " if match_on == "all" else " or "}}
+    {{ " and " if match_on == "all" else " or " }}
     {% endif -%}
     {% endfor %}
 {% endset %}

--- a/macros/schema_tests/string_matching/expect_column_values_to_match_regex_list.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_match_regex_list.sql
@@ -10,7 +10,7 @@
     {% for regex in regex_list %}
     {{ dbt_expectations.regexp_instr(column_name, regex, is_raw=is_raw, flags=flags) }} > 0
     {%- if not loop.last %}
-    {{ " and " if match_on == "all" else " or "}}
+    {{ " and " if match_on == "all" else " or " }}
     {% endif -%}
     {% endfor %}
 {% endset %}

--- a/macros/schema_tests/string_matching/expect_column_values_to_not_match_like_pattern_list.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_not_match_like_pattern_list.sql
@@ -8,7 +8,7 @@
     {% for like_pattern in like_pattern_list %}
     {{ dbt_expectations._get_like_pattern_expression(column_name, like_pattern, positive=False) }}
     {%- if not loop.last %}
-    {{ " and " if match_on == "all" else " or "}}
+    {{ " and " if match_on == "all" else " or " }}
     {% endif -%}
     {% endfor %}
 {% endset %}

--- a/macros/schema_tests/string_matching/expect_column_values_to_not_match_regex_list.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_not_match_regex_list.sql
@@ -10,7 +10,7 @@
 {% for regex in regex_list %}
 {{ dbt_expectations.regexp_instr(column_name, regex, is_raw=is_raw, flags=flags) }} = 0
 {%- if not loop.last %}
-{{ " and " if match_on == "all" else " or "}}
+{{ " and " if match_on == "all" else " or " }}
 {% endif -%}
 {% endfor %}
 {% endset %}

--- a/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
+++ b/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
@@ -36,7 +36,7 @@ with latest_grouped_timestamps as (
         {% endif %}
 
     {% if group_by -%}
-    {{  dbt_expectations.group_by(group_by | length) }}
+    {{ dbt_expectations.group_by(group_by | length) }}
     {%- endif %}
 ),
 total_row_counts as (
@@ -48,7 +48,7 @@ total_row_counts as (
     from
         latest_grouped_timestamps
     {% if group_by -%}
-    {{  dbt_expectations.group_by(group_by | length) }}
+    {{ dbt_expectations.group_by(group_by | length) }}
     {%- endif %}
 
 

--- a/macros/utils/datatypes.sql
+++ b/macros/utils/datatypes.sql
@@ -1,4 +1,4 @@
-{# timestamp  -------------------------------------------------     #}
+{# timestamp  ------------------------------------------------- #}
 {%- macro type_timestamp() -%}
   {{ return(adapter.dispatch('type_timestamp', 'dbt_expectations')()) }}
 {%- endmacro -%}
@@ -19,7 +19,7 @@
     timestamp(3)
 {%- endmacro %}
 
-{# datetime  -------------------------------------------------     #}
+{# datetime  ------------------------------------------------- #}
 
 {% macro type_datetime() -%}
   {{ return(adapter.dispatch('type_datetime', 'dbt_expectations')()) }}


### PR DESCRIPTION
## Summary of Changes

Fixed linting errors via:

```sh
dbt lint --fix
```

using Fusion.

https://docs.getdbt.com/reference/commands/lint?version=2.0

I couldn't get it to run in this repository directly, so I added this repository as a [local package](https://docs.getdbt.com/docs/build/packages?version=2.0&name=Fusion#local-packages) and ran from my dbt project.

## Why Do We Need These Changes

My project uses dbt Fusion. Running `dbt lint` from there was giving me a number of linting warnings:

```
$ dbt lint
...
============================================================================================= Errors and Warnings =============================================================================================
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{ regexp_query}} [JJ01]
  --> dbt_packages/dbt_expectations/macros/regex/regexp_instr.sql:79:8
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{ " and " if match_on == "all" else " or "}} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/string_matching/expect_column_values_to_not_match_like_pattern_list.sql:11:5
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {% macro default__quantile(field, quantile, partition)  -%} [JJ01]
  --> dbt_packages/dbt_expectations/macros/math/percentile_cont.sql:5:1
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{ regexp_query}} [JJ01]
  --> dbt_packages/dbt_expectations/macros/regex/regexp_instr.sql:79:35
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {# Flag syntax is xyz (set) or -xyz (clear) or xy-z (set xy, clear z).  #} [JJ01]
  --> dbt_packages/dbt_expectations/macros/regex/regexp_instr.sql:100:1
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {# Regex explanation: do not allow consecutive dashes, accept all re2 flags and clear operator, do not end with a dash  #} [JJ01]
  --> dbt_packages/dbt_expectations/macros/regex/regexp_instr.sql:102:1
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {# timestamp  -------------------------------------------------     #} [JJ01]
  --> dbt_packages/dbt_expectations/macros/utils/datatypes.sql:1:1
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {# datetime  -------------------------------------------------     #} [JJ01]
  --> dbt_packages/dbt_expectations/macros/utils/datatypes.sql:22:1
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{ " and " if match_on == "all" else " or "}} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/string_matching/expect_column_values_to_not_match_regex_list.sql:13:1
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {%- endif  %} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/column_values_basic/expect_column_values_to_be_decreasing.sql:34:13
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{  dbt_expectations.group_by(group_by | length) }} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql:39:5
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {%- endif  %} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/column_values_basic/expect_column_values_to_be_increasing.sql:37:13
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{  dbt_expectations.group_by(group_by | length) }} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql:51:5
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{ target_tz}} [JJ01]
  --> dbt_packages/dbt_date/macros/calendar_date/convert_timezone.sql:16:39
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{  dbt_expectations.group_by(1 + group_by_length) }} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql:72:9
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{  dbt_expectations.group_by(group_by | length) }} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/distributional/expect_column_values_to_be_within_n_stdevs.sql:27:5
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{interval}} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/distributional/expect_row_values_to_have_data_for_every_n_datepart.sql:68:18
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{ dbt.dateadd(
            date_part,
            "mod(
                cast(" ~ dbt.datediff("'" ~ start_date ~ "'", date_col, date_part) ~ " as " ~ dbt.type_int() ~ " ),
                cast(" ~ interval ~ " as  " ~ dbt.type_int() ~ " )
            ) * (-1)",
            "cast( " ~ dbt.date_trunc(date_part, date_col) ~ " as  " ~ dbt_expectations.type_datetime() ~ ")"
        )}} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/distributional/expect_row_values_to_have_data_for_every_n_datepart.sql:90:9
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{date_part}} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/distributional/expect_row_values_to_have_data_for_every_n_datepart.sql:108:14
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {%- if row_condition  %} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/multi-column/expect_compound_columns_to_be_unique.sql:28:5
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{adapter.quote("n_records")}} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/multi-column/expect_compound_columns_to_be_unique.sql:42:21
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{sum_total}} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/multi-column/expect_multicolumn_sum_to_equal.sql:13:44
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {% test expect_select_column_values_to_be_unique_within_record(model,
                                                    column_list,
                                                    quote_columns=False,
                                                    ignore_row_if="all_values_are_missing",
                                                    row_condition=None
                                                    )  -%} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/multi-column/expect_select_column_values_to_be_unique_within_record.sql:1:1
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {%- if row_condition  %} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/multi-column/expect_select_column_values_to_be_unique_within_record.sql:32:5
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{ " and " if match_on == "all" else " or "}} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/string_matching/expect_column_values_to_match_like_pattern_list.sql:11:5
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{ " and " if match_on == "all" else " or "}} [JJ01]
  --> dbt_packages/dbt_expectations/macros/schema_tests/string_matching/expect_column_values_to_match_regex_list.sql:13:5

============================================================================================== Execution Summary ==============================================================================================
Finished 'lint' with 26 warnings
```

I was able to work around that by adding `dbt_packages/` to a `.sqlfluffignore`, but figured others would run into this problem, so creating this pull request to avoid the problem.

## Reviewers
@GuruM
